### PR TITLE
fix: backdrop filter not working on mobile

### DIFF
--- a/src/components/header/header.scss
+++ b/src/components/header/header.scss
@@ -9,6 +9,7 @@ header {
   height: auto;
   margin: 0 auto;
   border-bottom: 0.5px solid $shadow-dark-900;
+  -webkit-backdrop-filter: blur(10px);
   backdrop-filter: blur(10px);
   translate: 0 -100%;
   z-index: 5;


### PR DESCRIPTION
- Backdrop filter CSS property not working on mobile devices.